### PR TITLE
Fixed a bug in hreflang-check.py - issue #6

### DIFF
--- a/polly/hreflang-check.py
+++ b/polly/hreflang-check.py
@@ -41,10 +41,10 @@ print
 
 print "Errors by hreflang_key:"
 for hreflang_key in test_page.hreflang_keys:
-    print "\t" + hreflang_key + " = " + str(test_page.errors_for_key[hreflang_key])
+    print "\t" + hreflang_key + " = " + str(test_page.issues_for_key[hreflang_key]['has_errors'])
 print
 
 print "Errors by url:"
 for url in test_page.alternate_urls():
-    print "\t" + url + " = " + str(test_page.errors_for_url[url])
+    print "\t" + url + " = " + str(test_page.issues_for_url[url]['has_errors'] )
 print


### PR DESCRIPTION
".errors_for_url" and ".errors_for_key" do not appear in polly.py.
However ".issues_for_key[key]['has_errors']" and ".issues_for_url[url]['has_errors']" do.
This change allows hreflang-check.py to run as specififed in the README.md without error.